### PR TITLE
fixes for cifv3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+minemeld_cifv3.egg-info/
 # Environments
 .venv
 venv/

--- a/cifv3/node.py
+++ b/cifv3/node.py
@@ -115,7 +115,8 @@ class Miner(BasePollerFT):
 
         # build attributes to return
         a = {}
-        a['itype'] = itype
+        # minemeld attrib is just called 'type'
+        a['type'] = itype
 
         for field in self.fields:
             if field in ['indicator', 'itype', 'confidence']:
@@ -127,7 +128,8 @@ class Miner(BasePollerFT):
             a['{}_{}'.format(self.prefix, field)] = item[field]
 
         if item.get('confidence'):
-            a['confidence'] = item['confidence']
+            # minemeld confidence scores are 0-100, so multiply CIF conf by 10 to equivocate
+            a['confidence'] = (item['confidence'] * 10)
 
         LOG.debug('{} - {}: {}'.format(self.name, indicator, a))
 

--- a/cifv3/node.py
+++ b/cifv3/node.py
@@ -32,12 +32,10 @@ class Miner(BasePollerFT):
         self.fields = ['tlp', 'group', 'reporttime', 'indicator', 'firsttime', 'lasttime', 'count', 'tags',
                        'description', 'confidence', 'rdata', 'provider']
 
-        self.side_config_path = self.config.get('side_config', None)
-        if self.side_config_path is None:
-            self.side_config_path = os.path.join(
-                os.environ['MM_CONFIG_DIR'],
-                '%s_side_config.yml' % self.name
-            )
+        self.side_config_path = os.path.join(
+            os.environ['MM_CONFIG_DIR'],
+            '{}_side_config.yml'.format(self.name)
+        )
 
         self._load_side_config()
 
@@ -62,6 +60,11 @@ class Miner(BasePollerFT):
                 self.filters.update(filters)
             else:
                 self.filters = filters
+
+        # for later param parsing by 'requests' library, list of tags needs to form a url
+        # such as /feed?tags=phishing,botnet as CIF server won't handle /feed?tags=phishing&tags=botnet
+        if isinstance(self.filters['tags'], list):
+            self.filters['tags'] = ','.join(map(str, self.filters['tags']))
 
     def _check_status(self, resp, expect=200):
         if resp.status_code == 400:

--- a/cifv3/prototypes/cifv3.yml
+++ b/cifv3/prototypes/cifv3.yml
@@ -16,7 +16,7 @@ prototypes:
       Miner for CIFv3 API. Based on CIFv3 SDK.
     config:
       source_name: cif.feed
-      indicator_types: null
+      indicator_types: [ any ]
       remote: null
       token: null
       verify_cert: true

--- a/cifv3/prototypes/cifv3.yml
+++ b/cifv3/prototypes/cifv3.yml
@@ -15,15 +15,8 @@ prototypes:
     description: >
       Miner for CIFv3 API. Based on CIFv3 SDK.
     config:
-      source_name: cif.feed
+      source_name: cifv3.Feed
       indicator_types: [ any ]
-      remote: null
-      token: null
-      verify_cert: true
-      filters:
-        itype: null
-        tags: null
-        confidence: null
       # age out of indicators
       age_out:
         sudden_death: true

--- a/cifv3/webui/cifv3.miner.info.html
+++ b/cifv3/webui/cifv3.miner.info.html
@@ -119,8 +119,8 @@
                 <tr>
                     <td>FILTERS</td>
                     <td tooltip="set feed filters" class="nodedetail-info-clickable" ng-click="sideConfig.setFilters()">
-                        <span ng-if="sideConfig.flattenedFilters === undefined"><em>Not set</span>
-                        <span ng-if="sideConfig.flattenedFilters">{{ sideConfig.flattenedFilters }}</span>
+                        <span ng-if="sideConfig.filters === undefined"><em>Not set</span>
+                        <span ng-if="sideConfig.filters">{{ sideConfig.filters }}</span>
                     </td>
                 </tr>
             </tbody>

--- a/cifv3/webui/cifv3.miner.sfilters.modal.html
+++ b/cifv3/webui/cifv3.miner.sfilters.modal.html
@@ -7,7 +7,7 @@
             <div class="form-group" id="fgOtype">
                 <label class="col-xs-4 control-label">ITYPE</label>
                 <div class="col-xs-6">
-                    <ui-select ng-model="vm.itype"
+                    <ui-select ng-model="vm.filters.itype"
                                theme="bootstrap"
                                reset-search-input="false"
                                style="width: 100%;"
@@ -25,14 +25,14 @@
                 <div class="col-xs-6">
                     <div class="input-group">
                         <div class="input-group-addon">&gt;=</div>
-                        <input type="text" class="form-control" ng-change="vm.changed = true" placeholder="Not set" ng-model="vm.confidence">
+                        <input type="number" class="form-control" ng-change="vm.changed = true" placeholder="Not set" ng-model="vm.filters.confidence | number : 1.0-2" min="0" max="10" ng-pattern="/^[0-9]+(\.[0-9]{1,2})?$/" step="0.01" />
                     </div>
                 </div>
             </div>
             <div class="form-group" id="fgTags">
                 <label class="col-xs-4 control-label">TAGS</label>
                 <div class="col-xs-6">
-                    <ui-select multiple ng-model="vm.tags" theme="bootstrap" tagging tagging-label=""
+                    <ui-select multiple ng-model="vm.filters.tags" theme="bootstrap" tagging tagging-label=""
                                on-select="vm.changed = true" on-remove="vm.changed = true">
                         <ui-select-match placeholder="Not set">{{$item}}</ui-select-match>
                         <ui-select-choices repeat="tag as tag in vm.defaultTags | filter: $select.search">

--- a/cifv3/webui/cifv3.miner.sfilters.modal.html
+++ b/cifv3/webui/cifv3.miner.sfilters.modal.html
@@ -2,58 +2,57 @@
     <h1 class="modal-title">CIFv3 FILTERS <span ng-if="vm.changed">*</span></h1>
 </div>
 <div class="modal-body">
-    <div class="row">
-        <form class="config-add-form form-horizontal m-t-xs">
-            <div class="form-group" id="fgItype">
-                <label class="col-xs-4 control-label">ITYPE</label>
-                <div class="col-xs-6">
-                    <ui-select ng-model="vm.filters.itype"
-                               theme="bootstrap"
-                               reset-search-input="false"
-                               style="width: 100%;"
-                               on-select="vm.changed = true"
-                               on-remove="vm.changed = true">
-                        <ui-select-match placeholder="Not set">{{$select.selected}}</ui-select-match>
-                        <ui-select-choices repeat="itype in vm.itypes | filter: $select.search">
-                            <span ng-bind-html="itype | highlight: $select.search"></span>
-                        </ui-select-choices>
-                    </ui-select>
-                </div>
-            </div>
-            <div class="form-group" id="fgConfidence">
-                <label class="col-xs-4 control-label">CONFIDENCE</label>
-                <div class="col-xs-6">
-                    <div class="input-group">
-                        <div class="input-group-addon">&gt;=</div>
-                        <input type="number" 
-			    class="form-control" 
-   			    ng-change="vm.changed = true" 
-			    placeholder="Not set" 
-			    ng-model="vm.filters.confidence" 
-			    min="0" max="10" step="0.5"
-			    ng-pattern="/^[0-9]+(\.[0-9]{1,2})?$/" 
-			/>
-                    </div>
-                </div>
-            </div>
-            <div class="form-group" id="fgTags">
-                <label class="col-xs-4 control-label">TAGS</label>
-                <div class="col-xs-6">
-                    <ui-select multiple ng-model="vm.filters.tags" theme="bootstrap" tagging tagging-label=""
-                               on-select="vm.changed = true" on-remove="vm.changed = true">
-                        <ui-select-match placeholder="Not set">{{$item}}</ui-select-match>
-                        <ui-select-choices repeat="tag as tag in vm.defaultTags | filter: $select.search">
-                            <div>
-                                <span ng-bind-html="tag | highlight: $select.search"></span>
-                            </div>
-                        </ui-select-choices>
-                </ui-select>
-                </div>
-            </div>
-        </form>
-    </div>
-</div>
-<div class="modal-footer">
-    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
-    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+    <div class="row"></div>
+    <form class="config-add-form form-horizontal m-t-xs" ng-submit="submit()">
+    	<div class="form-group" id="fgItype">
+	    <label class="col-xs-4 control-label">ITYPE</label>
+	    <div class="col-xs-6">
+	    	<ui-select ng-model="vm.filters.itype"
+		       theme="bootstrap"
+		       reset-search-input="false"
+		       style="width: 100%;"
+		       on-select="vm.changed = true"
+		       on-remove="vm.changed = true">
+		    <ui-select-match placeholder="Not set">{{$select.selected}}</ui-select-match>
+		    <ui-select-choices repeat="itype in vm.itypes | filter: $select.search">
+		    	<span ng-bind-html="itype | highlight: $select.search"></span>
+		    </ui-select-choices>
+	    	</ui-select>
+	    </div>
+    	</div>
+    	<div class="form-group" id="fgConfidence">
+	    <label class="col-xs-4 control-label">CONFIDENCE</label>
+	    <div class="col-xs-6">
+	    	<div class="input-group">
+		    <div class="input-group-addon">&gt;=</div>
+		    <input type="number" 
+		    	class="form-control" 
+		    	ng-change="vm.changed = true" 
+		    	placeholder="Not set" 
+		    	ng-model="vm.filters.confidence" 
+		    	min="0" max="10" step="0.5"
+		    	ng-pattern="/^[0-9]+(\.[0-9]{1,2})?$/" 
+		    />
+	    	</div>
+	    </div>
+    	</div>
+    	<div class="form-group" id="fgTags">
+	    <label class="col-xs-4 control-label">TAGS</label>
+	    <div class="col-xs-6">
+	    	<ui-select multiple ng-model="vm.filters.tags" theme="bootstrap"
+		       on-select="vm.changed = true" on-remove="vm.changed = true">
+		    <ui-select-match placeholder="Not set">{{$item}}</ui-select-match>
+		    <ui-select-choices repeat="tag as tag in vm.defaultTags | filter: $select.search">
+		    	<div>
+			    <span ng-bind-html="tag | highlight: $select.search"></span>
+		    	</div>
+		    </ui-select-choices>
+		</ui-select>
+	    </div>
+    	</div>
+    	<div class="modal-footer">
+	    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="submit" ng-click="vm.save()">OK</button>
+	    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+    	</div>
+    </form>
 </div>

--- a/cifv3/webui/cifv3.miner.sfilters.modal.html
+++ b/cifv3/webui/cifv3.miner.sfilters.modal.html
@@ -4,7 +4,7 @@
 <div class="modal-body">
     <div class="row">
         <form class="config-add-form form-horizontal m-t-xs">
-            <div class="form-group" id="fgOtype">
+            <div class="form-group" id="fgItype">
                 <label class="col-xs-4 control-label">ITYPE</label>
                 <div class="col-xs-6">
                     <ui-select ng-model="vm.filters.itype"
@@ -25,7 +25,14 @@
                 <div class="col-xs-6">
                     <div class="input-group">
                         <div class="input-group-addon">&gt;=</div>
-                        <input type="number" class="form-control" ng-change="vm.changed = true" placeholder="Not set" ng-model="vm.filters.confidence | number : 1.0-2" min="0" max="10" ng-pattern="/^[0-9]+(\.[0-9]{1,2})?$/" step="0.01" />
+                        <input type="number" 
+			    class="form-control" 
+   			    ng-change="vm.changed = true" 
+			    placeholder="Not set" 
+			    ng-model="vm.filters.confidence" 
+			    min="0" max="10" step="0.5"
+			    ng-pattern="/^[0-9]+(\.[0-9]{1,2})?$/" 
+			/>
                     </div>
                 </div>
             </div>

--- a/cifv3/webui/cifv3.miner.sremote.modal.html
+++ b/cifv3/webui/cifv3.miner.sremote.modal.html
@@ -3,17 +3,17 @@
 </div>
 <div class="modal-body">
     <div class="row">
-        <form class="config-add-form form-horizontal m-t-xs">
-            <div class="form-group">
-                <label class="col-xs-4 control-label">REMOTE</label>
-                <div class="col-xs-6">
-                    <input ng-model="vm.remote" rows="3" class="form-control" placeholder="CIF Remote URL" type="url" value="{{ vm.remote }}" />
-                </div>
-            </div>
-        </form>
     </div>
-</div>
-<div class="modal-footer">
-    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
-    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+    <form class="config-add-form form-horizontal m-t-xs" ng-submit="submit()">
+    	<div class="form-group">
+	    <label class="col-xs-4 control-label">REMOTE</label>
+	    <div class="col-xs-6">
+	    	<input ng-model="vm.remote" rows="3" class="form-control" placeholder="CIF Remote URL" type="url" value="{{ vm.remote }}" />
+	    </div>
+    	</div>
+	<div class="modal-footer">
+    	    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="submit" ng-click="vm.save()">OK</button>
+    	    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+	</div>
+    </form>
 </div>

--- a/cifv3/webui/cifv3.miner.sremote.modal.html
+++ b/cifv3/webui/cifv3.miner.sremote.modal.html
@@ -7,7 +7,7 @@
             <div class="form-group">
                 <label class="col-xs-4 control-label">REMOTE</label>
                 <div class="col-xs-6">
-                    <textarea ng-model="vm.remote" rows="3" class="form-control" placeholder="CIF Remote URL"></textarea>
+                    <input ng-model="vm.remote" rows="3" class="form-control" placeholder="CIF Remote URL" type="url" value="{{ vm.remote }}" />
                 </div>
             </div>
         </form>

--- a/cifv3/webui/cifv3.miner.stoken.modal.html
+++ b/cifv3/webui/cifv3.miner.stoken.modal.html
@@ -7,7 +7,7 @@
             <div class="form-group">
                 <label class="col-xs-4 control-label">TOKEN</label>
                 <div class="col-xs-6">
-                    <textarea ng-model="vm.token" rows="3" class="form-control" placeholder="CIF Token"></textarea>
+                    <textarea type="text" ng-model="vm.token" rows="3" class="form-control" placeholder="CIF Token" ng-pattern="/^[a-z0-9]{80}$/">{{vm.token}}</textarea>
                 </div>
             </div>
         </form>

--- a/cifv3/webui/cifv3.miner.stoken.modal.html
+++ b/cifv3/webui/cifv3.miner.stoken.modal.html
@@ -3,17 +3,17 @@
 </div>
 <div class="modal-body">
     <div class="row">
-        <form class="config-add-form form-horizontal m-t-xs">
-            <div class="form-group">
-                <label class="col-xs-4 control-label">TOKEN</label>
-                <div class="col-xs-6">
-                    <textarea type="text" ng-model="vm.token" rows="3" class="form-control" placeholder="CIF Token" ng-pattern="/^[a-z0-9]{80}$/">{{vm.token}}</textarea>
-                </div>
-            </div>
-        </form>
     </div>
-</div>
-<div class="modal-footer">
-    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="button" ng-click="vm.save()">OK</button>
-    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+    <form class="config-add-form form-horizontal m-t-xs" ng-submit="submit()">
+    	<div class="form-group">
+	    <label class="col-xs-4 control-label" style="width: 13.3333%;">TOKEN</label>
+	    <div class="col-xs-6">
+	    	<input type="text" ng-model="vm.token" rows="3" class="form-control" placeholder="CIF Token" ng-pattern="/^[a-z0-9]{80}$/" style="width:450px;" />
+	    </div>
+    	</div>
+    	<div class="modal-footer">
+	    <button ng-disabled="!vm.valid()" class="btn btn-primary btn-sm" type="submit" ng-click="vm.save()">OK</button>
+	    <button class="btn btn-warning btn-sm" type="button" ng-click="vm.cancel()">CANCEL</button>
+    	</div>
+    </form>
 </div>

--- a/cifv3/webui/extension.js
+++ b/cifv3/webui/extension.js
@@ -64,6 +64,10 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
             side_config.verify_cert = vm.verify_cert;
         }
 
+	if (vm.filters) {
+	    side_config.flattenedFilters = vm.filters;
+	}
+
         return MinemeldConfigService.saveDataFile(
             nodename + '_side_config',
             side_config
@@ -86,14 +90,13 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
         mi.result.then((result) => {
             vm.remote = result.remote;
 
-            return vm.saveSideConfig();
-        })
-        .then(() => {
-            toastr.success('REMOTE SET');
-            vm.loadSideConfig();
-        }, (error) => {
-            toastr.error('ERROR SETTING REMOTE: ' + error.statusText);
-        });
+            return vm.saveSideConfig().then(() => {
+            	toastr.success('REMOTE SET');
+            	vm.loadSideConfig();
+            }, (error) => {
+            	toastr.error('ERROR SETTING REMOTE: ' + error.statusText);
+            });
+    	});
     };
 
     vm.setToken = function() {
@@ -109,16 +112,14 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
         mi.result.then((result) => {
             vm.token = result.token;
 
-            return vm.saveSideConfig();
-        })
-        .then((result) => {
-            toastr.success('TOKEN SET');
-            vm.loadSideConfig();
-        }, (error) => {
-            toastr.error('ERROR SETTING TOKEN: ' + error.statusText);
-        });
+            return vm.saveSideConfig().then((result) => {
+            	toastr.success('TOKEN SET');
+            	vm.loadSideConfig();
+            }, (error) => {
+            	toastr.error('ERROR SETTING TOKEN: ' + error.statusText);
+            });
+    	});
     };
-
 
     vm.toggleVerifyCert = function() {
         var p, new_value;
@@ -158,21 +159,20 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
             backdrop: 'static',
             animation: false,
             resolve: {
-                filters: () => { return this.filters; }
+                filters: () => { return vm.filters; }
             }
         });
 
         mi.result.then((result) => {
-            this.filters = result.filters;
+            vm.filters = result.filters;
 
-            return vm.saveSideConfig();
-        })
-        .then((result) => {
-            toastr.success('FILTERS SET');
-            vm.loadSideConfig();
-        }, (error) => {
+            return vm.saveSideConfig().then((result) => {
+            	toastr.success('FILTERS SET');
+            	vm.loadSideConfig();
+            }, (error) => {
             toastr.error('ERROR SETTING FILTERS: ' + error.statusText);
-        });
+            });
+    	});
     };
 
     vm.loadSideConfig();
@@ -240,14 +240,14 @@ function CIFv3FiltersController($modalInstance, filters) {
 
     vm.filters = filters;
 
-    itypes: string = [
+    vm.itypes = [
         'ipv4',
         'ipv6',
         'fqdn',
         'url'
     ];
 
-    defaultTags: string = [
+    vm.defaultTags = [
         'whitelist',
         'spam',
         'malware',

--- a/cifv3/webui/extension.js
+++ b/cifv3/webui/extension.js
@@ -193,7 +193,7 @@ function CIFv3RemoteController($modalInstance, remote) {
     vm.valid = function() {
         angular.element('#remote').removeClass('has-error');
 
-        if (!vm.remote) {
+        if (!vm.remote || vm.remote == null) {
             return false;
         }
 
@@ -221,7 +221,7 @@ function CIFv3TokenController($modalInstance, token) {
     vm.valid = function() {
         angular.element('#token').removeClass('has-error');
 
-        if (!vm.token) {
+        if (!vm.token || vm.token == null) {
             return false;
         }
 
@@ -280,17 +280,17 @@ function CIFv3FiltersController($modalInstance, filters) {
             return false;
         }
 
-	if (vm.filters.itype === undefined || vm.filters.itype.length === 0) {
+	if (vm.filters.itype === undefined || vm.filters.itype == null || vm.filters.itype.length === 0) {
 	    angular.element('#fgItype').addClass('has-error');
 	    return false;
 	}
 
-	if (vm.filters.confidence === undefined || vm.filters.confidence < 0 || vm.filters.confidence > 10) {
+	if (vm.filters.confidence === undefined || vm.filters.confidence < 0 || vm.filters.confidence > 10 || vm.filters.confidence == null) {
 	    angular.element('#fgConfidence').addClass('has-error');
 	    return false;
 	}
 
-	if (vm.filters.tags === undefined || vm.filters.tags.length === 0) {
+	if (vm.filters.tags === undefined || vm.filters.tags == null || vm.filters.tags.length === 0) {
 	    angular.element('#fgTags').addClass('has-error');
 	    return false;
 	}

--- a/cifv3/webui/extension.js
+++ b/cifv3/webui/extension.js
@@ -10,7 +10,7 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
     vm.remote = undefined;
     vm.token = undefined;
     vm.verify_cert = undefined;
-
+    vm.filters = undefined;
 
     vm.loadSideConfig = function() {
         var nodename = $scope.$parent.vm.nodename;
@@ -20,8 +20,8 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
             if (!result) {
                 return;
             }
-
-            if (result.remote) {
+            
+  	    if (result.remote) {
                 vm.remote = result.remote;
             } else {
                 vm.remote = undefined;
@@ -38,6 +38,12 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
             } else {
                 vm.verify_cert = undefined;
             }
+
+	    if (result.filters) {
+		vm.filters = result.filters;
+	    } else {
+		vm.filters = undefined;
+	    }
 
         }, (error) => {
             toastr.error('ERROR RETRIEVING NODE SIDE CONFIG: ' + error.status);
@@ -65,7 +71,7 @@ function CIFv3SideConfigController($scope, MinemeldConfigService, MineMeldRunnin
         }
 
 	if (vm.filters) {
-	    side_config.flattenedFilters = vm.filters;
+	    side_config.filters = vm.filters;
 	}
 
         return MinemeldConfigService.saveDataFile(
@@ -210,7 +216,7 @@ function CIFv3RemoteController($modalInstance, remote) {
 function CIFv3TokenController($modalInstance, token) {
     var vm = this;
 
-    vm.remote = token;
+    vm.token = token;
 
     vm.valid = function() {
         angular.element('#token').removeClass('has-error');
@@ -244,7 +250,12 @@ function CIFv3FiltersController($modalInstance, filters) {
         'ipv4',
         'ipv6',
         'fqdn',
-        'url'
+        'url',
+	'md5',
+	'sha1',
+	'sha256',
+	'sha512',
+	'email'
     ];
 
     vm.defaultTags = [
@@ -256,15 +267,33 @@ function CIFv3FiltersController($modalInstance, filters) {
         'honeypot',
         'botnet',
         'exploit',
-        'phishing'
+        'phishing',
+	'suspicious'
     ];
 
     vm.valid = function() {
-        //angular.element('#filters').removeClass('has-error');
+        angular.element('#fgItype').removeClass('has-error');
+	angular.element('#fgConfidence').removeClass('has-error');
+	angular.element('#fgTags').removeClass('has-error');
 
         if (!vm.filters) {
             return false;
         }
+
+	if (vm.filters.itype === undefined || vm.filters.itype.length === 0) {
+	    angular.element('#fgItype').addClass('has-error');
+	    return false;
+	}
+
+	if (vm.filters.confidence === undefined || vm.filters.confidence < 0 || vm.filters.confidence > 10) {
+	    angular.element('#fgConfidence').addClass('has-error');
+	    return false;
+	}
+
+	if (vm.filters.tags === undefined || vm.filters.tags.length === 0) {
+	    angular.element('#fgTags').addClass('has-error');
+	    return false;
+	}
 
         return true;
     };


### PR DESCRIPTION
- remove prototype level config for remote, token, filters
- all cif config now done at node-level (only 1 place now instead of 2)
- implement save/validation for each cif setting (like filters, token, remote)
- UX improvements
  - allow "enter" key to submit config changes when editing
  - input validation regex
  - fix multi select on tags to prevent de novo tag additions
  - confidence input is now a float between 0 - 10